### PR TITLE
fix 'text' update in watch

### DIFF
--- a/src/LabelEdit.vue
+++ b/src/LabelEdit.vue
@@ -74,6 +74,8 @@ export default{
 		text: function(value){
 			if(value==''||value==undefined){
 				this.label = this.vplaceholder
+			}else{
+			  this.label = value
 			}
 		}
 	}


### PR DESCRIPTION
Fix: when the prop 'text' updated by user, the label does not update correctly.